### PR TITLE
Update changelog with note that Node.js version 16+ is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project attempts to adhere to Semantic Versioning.
 
 ### Added
 
-* Added FileQC `alert` property to OpenAPI documentation
+* FileQC `alert` property to OpenAPI documentation
+* Requirement for Node.js version 16+ 
 
 ## 3.0.1: [2023-01-05]
 


### PR DESCRIPTION
I updated the README to require a supported version of Node.js in [another PR](https://github.com/oicr-gsi/nabu/pull/78) for a dependency update (that required a more modern version of Node.js), but forgot to modify the changelog. This is that missing changelog line.