### PR TITLE
Keep all test database configuration in a single file

### DIFF
--- a/components/fileqcs/fileQcDao.js
+++ b/components/fileqcs/fileQcDao.js
@@ -1,8 +1,14 @@
 'use strict';
 
-const dbConnectionString = `postgres://${process.env.DB_USER}:${process.env.DB_PW}@${process.env.DB_HOST}:${process.env.DB_PORT}/${process.env.DB_NAME}`;
 const pgp = require('pg-promise')({});
-const pg = pgp(dbConnectionString);
+const connectionConfig = {
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  database: process.env.DB_NAME,
+  user: process.env.DB_USER,
+  password: process.env.DB_PW,
+};
+const pg = pgp(connectionConfig);
 const queryStream = require('pg-query-stream');
 const logger = require('../../utils/logger').logger;
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "fw:migrate": "docker run --rm -v $(pwd)/conf:/flyway/conf -v $(pwd)/sql:/flyway/sql --network=host flyway/flyway migrate",
     "fw:test-clean": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/migrations:/flyway/sql --network=host flyway/flyway -cleanDisabled=false clean",
     "fw:test-migrate": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/migrations:/flyway/sql --network=host flyway/flyway migrate",
-    "pretest": ". test/setup_test_dbs.sh"
+    "pretest": ". test/setup_test_dbs.sh",
+    "posttest": ". test/stop_test_dbs.sh"
   },
   "lint-staged": {
     "*.js": [

--- a/test/.env
+++ b/test/.env
@@ -7,6 +7,7 @@ SQLITE_LOCATION=test
 PORT=3005
 NODE_ENV=test
 DEBUG=true
+PG_DB_CONTAINER_NAME=pgtestdb
 
 NO_SSL=true
 # Flag for whether AD-authenticated endpoint should be accessible (for implementing GR-689)

--- a/test/flyway.conf
+++ b/test/flyway.conf
@@ -1,4 +1,0 @@
-flyway.url=jdbc:postgresql://localhost:5436/qcdbtest
-flyway.user=test
-flyway.password=test
-flyway.cleanDisabled=false

--- a/test/setup_test_dbs.sh
+++ b/test/setup_test_dbs.sh
@@ -1,11 +1,18 @@
 #!/bin/bash
 
-PG_DB_CONTAINER_NAME="pgtestdb"  # Also used in package.json to stop the container after the test
+# source the .testenv file to use its variables
+. test/.env
 
-# stop any previously-running test containers
-docker stop "${PG_DB_CONTAINER_NAME}"
+docker stop "${PG_DB_CONTAINER_NAME}" || true  # it's fine if the container isn't running
+
+# create flyway.conf file
+echo "flyway.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}" > test/flyway.conf
+echo "flyway.user=${DB_USER}" >> test/flyway.conf
+echo "flyway.password=${DB_PW}" >> test/flyway.conf
+echo "flyway.cleanDisabled=false" >> test/flyway.conf
+
 # set up the Postgres database
-docker run -d --rm --name "${PG_DB_CONTAINER_NAME}" -p 5436:5432 -e POSTGRES_USER=test -e POSTGRES_PASSWORD=test -e POSTGRES_DB=qcdbtest postgres:12-alpine -c shared_buffers=500MB -c fsync=off 
+docker run -d --rm --name "${PG_DB_CONTAINER_NAME}" -p 5436:5432 -e POSTGRES_USER="${DB_USER}" -e POSTGRES_PASSWORD="${DB_PW}" -e POSTGRES_DB="${DB_NAME}" postgres:12-alpine -c shared_buffers=500MB -c fsync=off 
 
 # since we need to mount all the migrations into a single directory, the "regular" migrations need to be
 # copied into the test folder, then deleted after.

--- a/test/stop_test_dbs.sh
+++ b/test/stop_test_dbs.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. test/.env
+
+docker stop "${PG_DB_CONTAINER_NAME}"
+rm $(pwd)/test/flyway.conf


### PR DESCRIPTION
Reduce the duplication across (so many) files

`N/A` Includes a change file
`N/A` Updates developer documentation `(not updated, but now actually works "out of the box" as it was advertised to)`
