### PR TITLE
Standardize URL queries: use same URL components for querying by 'not accomplished step' and writing back 'accomplished step'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project attempts to adhere to Semantic Versioning.
 
 * Ability to request Vidarr metadata for a case
 
+### Changed
+
+* Standardized URLs: used same URL components for querying by "not completed a step" as "write back to indicate step is complete"
+
 ### Fixed
 
 * Can now query by optional "not" steps in `/cases` endpoint

--- a/components/case/caseController.js
+++ b/components/case/caseController.js
@@ -8,6 +8,7 @@ const {
   ConflictingDataError,
 } = require('../../utils/controllerUtils');
 const logger = require('../../utils/logger').logger;
+const urls = require('../../utils/urlSlugs');
 
 function arraysEquals (array1, array2) {
   return (
@@ -41,16 +42,16 @@ const allCaseArchives = async (req, res, next) => {
     const query = req.query.not;
     let cases;
     if (query) {
-      if (query == 'copied-to-staging') {
+      if (query == urls.filesCopiedToOffsiteStagingDir) {
         cases = await caseDao.getByFilesNotCopiedToOffsiteStagingDir();
         res.status(200).send(cases);
-      } else if (query == 'sent-offsite') {
+      } else if (query == urls.filesSentOffsite) {
         cases = await caseDao.getByFilesNotSentOffsite();
         res.status(200).send(cases);
-      } else if (query == 'sent-to-vidarr-archival') {
+      } else if (query == urls.filesLoadedIntoVidarrArchival) {
         cases = await caseDao.getByFilesNotLoadedIntoVidarrArchival();
         res.status(200).send(cases);
-      } else if (query == 'unloaded') {
+      } else if (query == urls.caseFilesUnloaded) {
         cases = await caseDao.getByFilesNotUnloaded();
         res.status(200).send(cases);
       }

--- a/swagger.json
+++ b/swagger.json
@@ -229,7 +229,7 @@
           "schema": {
             "type": "string"
           },
-          "description": "Optional parameter to filter by outstanding case archiving work. Permitted values are: 'copied-to-staging', 'sent-offsite', 'sent-to-vidarr-archival', 'unloaded'"
+          "description": "Optional parameter to filter by outstanding case archiving work. Permitted values are: 'copied-to-offsite-staging', 'sent-offsite', 'sent-to-vidarr-archival', 'unloaded'"
         }],
         "responses": {
           "200": {
@@ -335,7 +335,7 @@
         }
       }
     },
-    "/case/{caseIdentifier}/files-copied-to-offsite-staging-dir": {
+    "/case/{caseIdentifier}/copied-to-offsite-staging": {
       "put": {
         "summary": "Case archive files moved to offsite staging directory",
         "description": "Indicate that this case archive's files have been moved to the offfsite staging directory",
@@ -379,7 +379,7 @@
         }
       }
     },
-    "/case/{caseIdentifier}/files-sent-offsite": {
+    "/case/{caseIdentifier}/sent-offsite": {
       "put": {
         "summary": "Case archive files were sent offsite",
         "description": "Indicate that this case archive's files have been archived offsite",
@@ -427,7 +427,7 @@
         }
       }
     },
-    "/case/{caseIdentifier}/files-loaded-into-vidarr-archival": {
+    "/case/{caseIdentifier}/sent-to-vidarr-archival": {
       "put": {
         "summary": "Case archive files loaded into vidarr-archival",
         "description": "Indicate that this case archive's files have been loaded into vidarr-archival",
@@ -470,7 +470,7 @@
         }
       }
     },
-    "/case/{caseIdentifier}/case-files-unloaded": {
+    "/case/{caseIdentifier}/unloaded": {
       "put": {
         "summary": "Case archive files deleted from production vidarr",
         "description": "Record that this case archive's files have been deleted from production vidarr",

--- a/utils/urlSlugs.js
+++ b/utils/urlSlugs.js
@@ -1,8 +1,8 @@
 'use strict';
 
 module.exports = {
-  caseFilesUnloaded: 'case-files-unloaded',
-  filesCopiedToOffsiteStagingDir: 'files-copied-to-offsite-staging-dir',
-  filesLoadedIntoVidarrArchival: 'files-loaded-into-vidarr-archival',
-  filesSentOffsite: 'files-sent-offsite',
+  caseFilesUnloaded: 'unloaded',
+  filesCopiedToOffsiteStagingDir: 'copied-to-offsite-staging',
+  filesLoadedIntoVidarrArchival: 'sent-to-vidarr-archival',
+  filesSentOffsite: 'sent-offsite',
 };


### PR DESCRIPTION
- [x] Includes a change file
- [x] Updates developer documentation
