### PR TITLE
Run test database setup/cleaning commands synchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Flyway database migration credentials file
 conf/flyway.conf
+test/flyway.conf
 # environment variables file
 .env
 !test/.env

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "pre-commit": "npm test && lint-staged",
     "fw:clean": "docker run --rm -v $(pwd)/conf:/flyway/conf -v $(pwd)/sql:/flyway/sql --network=host flyway/flyway clean",
     "fw:migrate": "docker run --rm -v $(pwd)/conf:/flyway/conf -v $(pwd)/sql:/flyway/sql --network=host flyway/flyway migrate",
-    "fw:test-clean": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/migrations:/flyway/sql --network=host flyway/flyway -cleanDisabled=false clean && sleep .5",
-    "fw:test-migrate": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/migrations:/flyway/sql --network=host flyway/flyway migrate",
+    "fw:test-clean": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway -cleanDisabled=false clean && sleep .5",
+    "fw:test-migrate": "docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway migrate",
     "pretest": ". test/setup_test_dbs.sh",
     "posttest": ". test/stop_test_dbs.sh"
   },

--- a/test/archiveTest.js
+++ b/test/archiveTest.js
@@ -55,9 +55,10 @@ const isValidDate = (date) => {
 };
 
 describe('case archive tracking', () => {
-  beforeEach(async () => {
-    await cmd.run('npm run fw:test-clean; npm run fw:test-migrate');
-  });
+   before(function () {
+     this.timeout(10000);
+     cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
+   });
 
   describe('case + archive operations', () => {
     it('it should retrieve an archive entry with case data for a given case identifier', (done) => {

--- a/test/authTest.js
+++ b/test/authTest.js
@@ -60,8 +60,9 @@ const getTokenSpecifyAuth = (server, token, requestBody = {}) => {
 };
 
 describe('case sign-off tracking', () => {
-  beforeEach(async () => {
-    await cmd.run('npm run fw:test-clean; npm run fw:test-migrate');
+  before(function () {
+    this.timeout(10000);
+    cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
   });
 
   describe('case sign-off authorization operations', () => {

--- a/test/create_fpr_table.sql
+++ b/test/create_fpr_table.sql
@@ -1,0 +1,1 @@
+../components/fpr/create_fpr_table.sql

--- a/test/fileqcTest.js
+++ b/test/fileqcTest.js
@@ -18,13 +18,8 @@ const controller = rewire('../components/fileqcs/fileQcsController');
 chai.use(chaiHttp);
 chai.use(chaiExclude);
 
-const recreateFprDb = async (cmd) => {
-  await cmd.run(
-    'sqlite3 ' +
-      process.env.SQLITE_LOCATION +
-      '/fpr.db < ' +
-      path.resolve(__dirname, './migrations/create_test_fpr.sql')
-  );
+const recreateFprDb = () => {
+  cmd.runSync('cd ' + process.env.SQLITE_LOCATION + '; sqlite3 fpr.db < create_fpr_table.sql');
 };
 
 describe('Unit test FileQcController', () => {
@@ -258,11 +253,13 @@ const deleteFileQcs = (server, requestBody = {}) => {
 };
 
 describe('available constants', () => {
-  before(async () => {
+  before(function () {
+    this.timeout(10000);
     recreateFprDb(cmd);
   });
-  beforeEach(async () => {
-    await cmd.run('npm run fw:test-clean; npm run fw:test-migrate');
+  beforeEach(function () {
+    this.timeout(10000);
+    cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
   });
   describe('GET available constants', () => {
     it('it should list available projects and workflows', (done) => {
@@ -279,11 +276,13 @@ describe('available constants', () => {
 });
 
 describe('FileQC', () => {
-  before(async () => {
+  before(function () {
+    this.timeout(10000);
     recreateFprDb(cmd);
   });
-  beforeEach(async () => {
-    await cmd.run('npm run fw:test-clean; npm run fw:test-migrate');
+  beforeEach(function () {
+    this.timeout(10000);
+    cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
   });
 
   describe('get fileQc by fileid or fileswid', () => {

--- a/test/fileqcTest.js
+++ b/test/fileqcTest.js
@@ -436,9 +436,9 @@ describe('FileQC', () => {
             expect(
               res.body.fileqcs.filter((f) => f.qcstatus == 'PENDING')
             ).to.have.lengthOf(2);
+            done();
           });
-        });
-        done();
+        });       
       });
     });
 
@@ -532,8 +532,8 @@ describe('FileQC', () => {
           expect(res.body.fileqcs).to.have.lengthOf(1);
           expect(res.body.fileqcs[0]).to.have.property('upstream');
           expect(res.body.fileqcs[0].qcstatus).to.equal('PASS');
+          done();
         });
-        done();
       });
     });
 
@@ -566,9 +566,9 @@ describe('FileQC', () => {
             expect(res.body.fileqcs).to.have.lengthOf(1);
             expect(res.body.fileqcs[0]).to.have.property('upstream');
             expect(res.body.fileqcs[0].qcstatus).to.be.equal('FAIL');
+            done();
           });
         });
-        done();
       });
     });
   });
@@ -640,8 +640,8 @@ describe('FileQC', () => {
           getFileQcs(server, { fileswids: ['12016'] }).end((err, res) => {
             expect(res.status).to.equal(200);
             expect(res.body.fileqcs).to.be.empty;
+            done();
           });
-          done();
         });
       });
     });

--- a/test/setup_test_dbs.sh
+++ b/test/setup_test_dbs.sh
@@ -1,36 +1,30 @@
 #!/bin/bash
+set -eu
 
 # source the .testenv file to use its variables
 . test/.env
 
-docker stop "${PG_DB_CONTAINER_NAME}" || true  # it's fine if the container isn't running
+docker rm -f "${PG_DB_CONTAINER_NAME}" || true  # it's fine if the container isn't running
 
 # create flyway.conf file
 echo "flyway.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}" > test/flyway.conf
 echo "flyway.user=${DB_USER}" >> test/flyway.conf
 echo "flyway.password=${DB_PW}" >> test/flyway.conf
 echo "flyway.cleanDisabled=false" >> test/flyway.conf
+echo "flyway.locations=filesystem:/flyway/migrations,filesystem:/flyway/testdata" >> test/flyway.conf
 
 # set up the Postgres database
-docker run -d --rm --name "${PG_DB_CONTAINER_NAME}" -p 5436:5432 -e POSTGRES_USER="${DB_USER}" -e POSTGRES_PASSWORD="${DB_PW}" -e POSTGRES_DB="${DB_NAME}" postgres:12-alpine -c shared_buffers=500MB -c fsync=off 
-
-# since we need to mount all the migrations into a single directory, the "regular" migrations need to be
-# copied into the test folder, then deleted after.
-mkdir -p test/sql
-cp sql/V*.sql test/sql/
-cp test/migrations/V9*.sql test/sql/
-cp components/fpr/create_fpr_table.sql test/migrations/
+docker run -d --rm --name "${PG_DB_CONTAINER_NAME}" -p 5436:5432 -e POSTGRES_USER="${DB_USER}" -e POSTGRES_PASSWORD="${DB_PW}" -e POSTGRES_DB="${DB_NAME}" postgres:12-alpine -c shared_buffers=500MB -c fsync=off
 
 CURRENT=$(pwd)
 cd test/
 export SQLITE_LOCATION=$(pwd)
-sqlite3 fpr.db < migrations/create_fpr_table.sql
+sqlite3 fpr.db < create_fpr_table.sql
 echo "Recreated FPR test table"
 cd "${CURRENT}"
 
-docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/sql:/flyway/sql --network=host flyway/flyway clean && \
-		docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/test/sql:/flyway/sql --network=host flyway/flyway migrate
+# wait for PG_DB_CONTAINER_NAME to be ready
+while ! docker exec -it pgtestdb pg_isready -U postgres; do sleep 1; done
 
-ls $(pwd)/test/sql
-rm -r $(pwd)/test/sql
-rm $(pwd)/test/migrations/create_fpr_table.sql
+docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway clean
+docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway migrate

--- a/test/setup_test_dbs.sh
+++ b/test/setup_test_dbs.sh
@@ -24,7 +24,7 @@ echo "Recreated FPR test table"
 cd "${CURRENT}"
 
 # wait for PG_DB_CONTAINER_NAME to be ready
-while ! docker exec -it pgtestdb pg_isready -U postgres; do sleep 1; done
+while ! docker exec pgtestdb pg_isready -U postgres; do sleep 1; done
 
 docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway clean
 docker run --rm -v $(pwd)/test:/flyway/conf -v $(pwd)/sql:/flyway/migrations -v $(pwd)/test/migrations:/flyway/testdata --network=host flyway/flyway migrate

--- a/test/signoffTest.js
+++ b/test/signoffTest.js
@@ -63,8 +63,9 @@ const getAllSignoffs = (server) => {
 };
 
 describe('case sign-off tracking', () => {
-  beforeEach(async () => {
-    await cmd.run('npm run fw:test-clean; npm run fw:test-migrate');
+  before(function () {
+    this.timeout(5000);
+    cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
   });
 
   describe('case sign-off operations', () => {

--- a/test/signoffTest.js
+++ b/test/signoffTest.js
@@ -64,7 +64,7 @@ const getAllSignoffs = (server) => {
 
 describe('case sign-off tracking', () => {
   before(function () {
-    this.timeout(5000);
+    this.timeout(10000);
     cmd.runSync('npm run fw:test-clean; npm run fw:test-migrate');
   });
 

--- a/test/stop_test_dbs.sh
+++ b/test/stop_test_dbs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
+set -eu
 
 . test/.env
 
-docker stop "${PG_DB_CONTAINER_NAME}"
+docker rm -f "${PG_DB_CONTAINER_NAME}"
 rm $(pwd)/test/flyway.conf


### PR DESCRIPTION
The database setup commands were running alongside the test execution. Reorganized flyway commands so that copying of data is not needed. Docker updates to better cleanup and ensure we're working with a clean db.

Jira ticket:

- [ ] Includes a change file
- [ ] Updates developer documentation
