### PR TITLE
Improve Prometheus HTTP monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project attempts to adhere to Semantic Versioning.
   * `copyOutFile`, the contents of the Vidarr copy-out file for the case
 * Improve error messages
 
+### Fixed
+
+* Prometheus HTTP monitoring
+
 ## 3.11.0: [2025-05-07]
 
 ### Added


### PR DESCRIPTION
Jira ticket: GP-4721

- [x] Includes a change file
- [ ] Updates developer documentation

Fixes issue where HTTP status code wasn't being correctly monitored. 
Removes function that required developers to remember to add new endpoints to monitoring - monitor everything by default.