### PR TITLE
Better practice for error logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project attempts to adhere to Semantic Versioning.
 
 ## UNRELEASED
 
+### Fixed
+
+* better practice for error logging to capture the stack trace correctly
+
 ## 3.16.3 [2026-04-22]
 
 ### Fixed

--- a/app.js
+++ b/app.js
@@ -40,11 +40,7 @@ const errorHandler = (err, req, res, next) => {
     });
   } else {
     // unexpected error, so log it
-    logger.error({
-      error: 'Unexpected error',
-      details: err,
-      endpoint: req.originalUrl,
-    });
+    logger.error(err);
     res.status(500);
     res.json({ errors: ['An unexpected error has occurred.'] });
   }
@@ -142,12 +138,8 @@ app.get('/metrics', async (req, res) => {
   try {
     const mostRecentImportTime = await fileQc.getMostRecentFprImportTime();
     prom.mostRecentFprImport.set(mostRecentImportTime);
-  } catch (e) {
-    logger.error({
-      error: 'Error getting most recent File Provenance Report import time',
-      details: e,
-      method: '/metrics endpoint',
-    });
+  } catch (err) {
+    logger.error(err);
   }
   res.set('Content-Type', prom.prometheus.register.contentType);
   res.end(await prom.prometheus.register.metrics());

--- a/components/fileqcs/fileQcDao.js
+++ b/components/fileqcs/fileQcDao.js
@@ -165,7 +165,7 @@ const deleteFileQcs = (fileIds, username) => {
               return resolve({ success: yay, errors: nay });
             })
             .catch((err) => {
-              logger.error({ error: err, method: 'deleteFileQcs' });
+              logger.error(err);
               reject(new Error(err));
             });
         } else {
@@ -173,7 +173,7 @@ const deleteFileQcs = (fileIds, username) => {
         }
       })
       .catch((err) => {
-        logger.error({ error: err, method: `deleteFqcs:${username}` });
+        logger.error(err);
         reject(new Error(err));
       });
   });

--- a/utils/controllerUtils.js
+++ b/utils/controllerUtils.js
@@ -100,7 +100,7 @@ function streamResponse (req, res, daoFn, transformAndSend, methodName, logger) 
         return;
       }
       // For real errors, log them instead of re-throwing into the void
-      logger.error({ error: 'Stream promise rejected', details: err, method: methodName });
+      logger.error(err);
     });
     logger.info({
       streamRowsProcessed: streamed.processed,


### PR DESCRIPTION
Pass in the entire error so it can format the stack trace properly, which will do a lot of the "include method" parts that were being done manually

Jira ticket: none

- [x] Includes a change file
- [x] Updates developer documentation (or n/a)
